### PR TITLE
Add CMake and Makefile support for Hashmap project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@
 *.app
 
 .vscode/
+build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.10)
+project(MyProject VERSION 1.0)
+
+set(PROJECT_NAME_HASHMAP "HASHMAP")
+if (UNIX)
+    set(PROJECT_NAME_HASHMAP "${PROJECT_NAME_HASHMAP}.exe")
+endif()
+
+set(CMAKE_C_STANDARD 11)
+
+add_executable(${PROJECT_NAME_HASHMAP} HashMaps/hashmap.c)
+set_target_properties(${PROJECT_NAME_HASHMAP} PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/bin")
+target_compile_options(${PROJECT_NAME_HASHMAP} PRIVATE -Wall -Wextra -Wpedantic -Werror)

--- a/HashMaps/hashmap.c
+++ b/HashMaps/hashmap.c
@@ -62,7 +62,7 @@ void put(HashMap* map, KEY key, VALUE val) {
 VALUE get(HashMap* map, KEY key) {
     int hashvalue = hash(key);
     if (map->items[hashvalue] == NULL) 
-        return NULL;
+        return -1;
     if (map->items[hashvalue]->next == NULL)
         return map->items[hashvalue]->value->value;
     
@@ -73,7 +73,7 @@ VALUE get(HashMap* map, KEY key) {
         node = node->next;
     }
 
-    return NULL;
+    return -1;
 }
 
 int main() {

--- a/README.md
+++ b/README.md
@@ -2,5 +2,7 @@
 
 All files included in my Youtube series: [Under the Hood](https://www.youtube.com/channel/UC8co7d52--VLDIHwpt3SXfw)
 
+## Build Instructions
+
 If you want to build the files yourself, you'll need `CMake` and `Ninja`, along with a `C` compiler.
 After you have the required tools, run `make reset` to initialize `CMake`, and check inside the `makefile` to see what run commands there are.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # Under-the-Hood
-All files included in my Youtube series: Under the Hood
+
+All files included in my Youtube series: [Under the Hood](https://www.youtube.com/channel/UC8co7d52--VLDIHwpt3SXfw)
+
+If you want to build the files yourself, you'll need `CMake` and `Ninja`, along with a `C` compiler.
+After you have the required tools, run `make reset` to initialize `CMake`, and check inside the `makefile` to see what run commands there are.

--- a/makefile
+++ b/makefile
@@ -1,0 +1,15 @@
+.ONESHELL:
+
+reset:
+	rmdir build
+	mkdir build
+	cd build
+	cmake -GNinja ..
+
+run-hashmap:
+	ninja -C build
+	ifeq ($(OS),Windows_NT)
+		.\HASHMAP.exe
+	else
+		./HASHMAP.exe
+	endif

--- a/makefile
+++ b/makefile
@@ -9,7 +9,7 @@ reset:
 run-hashmap:
 	ninja -C build
 ifeq ($(OS),Windows_NT)
-	.\HASHMAP.exe
+	.\bin\HASHMAP.exe
 else
-	./HASHMAP.exe
+	./bin/HASHMAP.exe
 endif

--- a/makefile
+++ b/makefile
@@ -8,8 +8,8 @@ reset:
 
 run-hashmap:
 	ninja -C build
-	ifeq ($(OS),Windows_NT)
-		.\HASHMAP.exe
-	else
-		./HASHMAP.exe
-	endif
+ifeq ($(OS),Windows_NT)
+	.\HASHMAP.exe
+else
+	./HASHMAP.exe
+endif


### PR DESCRIPTION
Introduce CMake configuration and a Makefile to streamline the build and run process for the Hashmap project. Update the README with build instructions and a YouTube link, and make minor fixes to the Makefile and return values in the get function. Exclude the build directory in .gitignore.